### PR TITLE
week9,10,11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/imap": "^0.8.35",
+        "html-to-text": "^8.2.1",
         "imap": "^0.8.19",
         "net": "^1.0.2",
         "postal-mime": "^1.0.13",
@@ -1160,6 +1161,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
+      "integrity": "sha512-J3jpy002TyBjd4N/p6s+s90eX42H2eRhK3SbsZuvTDv977/E8p2U3zikdiehyJja66do7FlxLomZLPlvl2/xaA==",
+      "dependencies": {
+        "domhandler": "^4.2.0",
+        "selderee": "^0.6.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -2883,8 +2896,7 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -3223,7 +3235,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3316,6 +3327,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -3328,6 +3344,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
     "node_modules/domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -3337,6 +3366,17 @@
         "node": ">=0.4",
         "npm": ">=1.2"
       }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
     },
     "node_modules/domexception": {
       "version": "2.0.1",
@@ -3357,6 +3397,33 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/duplexify": {
@@ -3446,6 +3513,14 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/errno": {
@@ -4964,6 +5039,14 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -5004,6 +5087,43 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/html-to-text": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-8.2.1.tgz",
+      "integrity": "sha512-aN/3JvAk8qFsWVeE9InWAWueLXrbkoVZy0TkzaGhoRBC2gCFEeRLDDJN3/ijIGHohy6H+SZzUQWN/hcYtaPK8w==",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.6.0",
+        "deepmerge": "^4.2.2",
+        "he": "^1.2.0",
+        "htmlparser2": "^6.1.0",
+        "minimist": "^1.2.6",
+        "selderee": "^0.6.0"
+      },
+      "bin": {
+        "html-to-text": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10.23.2"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
@@ -7063,8 +7183,7 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minipass": {
       "version": "3.1.6",
@@ -7173,6 +7292,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/moo": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
+    },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -7251,6 +7375,27 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -7666,6 +7811,18 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
     },
+    "node_modules/parseley": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.7.0.tgz",
+      "integrity": "sha512-xyOytsdDu077M3/46Am+2cGXEKM9U9QclBDv7fimY7e+BBlxh2JcBp2mgNsmkyA9uvgyTjVzDi7cP1v4hcFxbw==",
+      "dependencies": {
+        "moo": "^0.5.1",
+        "nearley": "^2.20.1"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -8002,6 +8159,23 @@
         }
       ]
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -8227,7 +8401,6 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       }
@@ -8362,6 +8535,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/selderee": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.6.0.tgz",
+      "integrity": "sha512-ibqWGV5aChDvfVdqNYuaJP/HnVBhlRGSRrlbttmlMpHcLuTqqbMH36QkSs9GEgj5M88JDYLI8eyP94JaQ8xRlg==",
+      "dependencies": {
+        "parseley": "^0.7.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/semver": {
@@ -11914,6 +12098,15 @@
         "rimraf": "^3.0.2"
       }
     },
+    "@selderee/plugin-htmlparser2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
+      "integrity": "sha512-J3jpy002TyBjd4N/p6s+s90eX42H2eRhK3SbsZuvTDv977/E8p2U3zikdiehyJja66do7FlxLomZLPlvl2/xaA==",
+      "requires": {
+        "domhandler": "^4.2.0",
+        "selderee": "^0.6.0"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -13292,8 +13485,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -13595,8 +13787,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "define-property": {
       "version": "2.0.2",
@@ -13670,6 +13861,11 @@
         "path-type": "^4.0.0"
       }
     },
+    "discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -13679,11 +13875,26 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      }
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
+    },
+    "domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
     },
     "domexception": {
       "version": "2.0.1",
@@ -13700,6 +13911,24 @@
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
           "dev": true
         }
+      }
+    },
+    "domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "requires": {
+        "domelementtype": "^2.2.0"
+      }
+    },
+    "domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "requires": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
       }
     },
     "duplexify": {
@@ -13780,6 +14009,11 @@
         "memory-fs": "^0.5.0",
         "tapable": "^1.0.0"
       }
+    },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
     },
     "errno": {
       "version": "0.1.8",
@@ -14947,6 +15181,11 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -14981,6 +15220,30 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "html-to-text": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-8.2.1.tgz",
+      "integrity": "sha512-aN/3JvAk8qFsWVeE9InWAWueLXrbkoVZy0TkzaGhoRBC2gCFEeRLDDJN3/ijIGHohy6H+SZzUQWN/hcYtaPK8w==",
+      "requires": {
+        "@selderee/plugin-htmlparser2": "^0.6.0",
+        "deepmerge": "^4.2.2",
+        "he": "^1.2.0",
+        "htmlparser2": "^6.1.0",
+        "minimist": "^1.2.6",
+        "selderee": "^0.6.0"
+      }
+    },
+    "htmlparser2": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      }
     },
     "http-proxy-agent": {
       "version": "4.0.1",
@@ -16555,8 +16818,7 @@
     "minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minipass": {
       "version": "3.1.6",
@@ -16638,6 +16900,11 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
+    "moo": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -16709,6 +16976,17 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "requires": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      }
     },
     "neo-async": {
       "version": "2.6.2",
@@ -17050,6 +17328,15 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
     },
+    "parseley": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.7.0.tgz",
+      "integrity": "sha512-xyOytsdDu077M3/46Am+2cGXEKM9U9QclBDv7fimY7e+BBlxh2JcBp2mgNsmkyA9uvgyTjVzDi7cP1v4hcFxbw==",
+      "requires": {
+        "moo": "^0.5.1",
+        "nearley": "^2.20.1"
+      }
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -17317,6 +17604,20 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
+    },
+    "randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "requires": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -17499,8 +17800,7 @@
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "reusify": {
       "version": "1.0.4",
@@ -17584,6 +17884,14 @@
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
         "ajv-keywords": "^3.5.2"
+      }
+    },
+    "selderee": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.6.0.tgz",
+      "integrity": "sha512-ibqWGV5aChDvfVdqNYuaJP/HnVBhlRGSRrlbttmlMpHcLuTqqbMH36QkSs9GEgj5M88JDYLI8eyP94JaQ8xRlg==",
+      "requires": {
+        "parseley": "^0.7.0"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@types/imap": "^0.8.35",
+    "html-to-text": "^8.2.1",
     "imap": "^0.8.19",
     "net": "^1.0.2",
     "postal-mime": "^1.0.13",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "joplin-plugin-email-plugin",
+  "name": "joplin-plugin-email",
   "version": "1.0.0",
   "scripts": {
     "dist": "webpack --joplin-plugin-config buildMain && webpack --joplin-plugin-config buildExtraScripts && webpack --joplin-plugin-config createArchive",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,6 @@ export const SECTION_NAME = 'Email_Plugin';
 export const EXPORT_TYPE = 'Export_Type';
 export const ATTACHMENTS = 'Attachments';
 export const PLUGIN_ICON = 'fa fa-envelope';
+export const ATTACHMENTS_STYLE = 'Attachments_Style';
+export const ACCOUNTS = 'Accounts';
+export const LAST_STATE = 'Last_State';

--- a/src/core/emailConfigure.ts
+++ b/src/core/emailConfigure.ts
@@ -3,7 +3,7 @@ import {emailProviders} from './emailProviders';
 import {ImapConfig} from '../model/imapConfig.model';
 import {EmailProvider} from 'src/model/emailProvider.model';
 
-export function emailConfigure(login: Login): ImapConfig | undefined {
+export function emailConfigure(login: Login): ImapConfig | never {
     let user = login.email;
     const password = login.password;
 
@@ -17,7 +17,7 @@ export function emailConfigure(login: Login): ImapConfig | undefined {
 
     // In the case that the email provider is not present in the email providers list, it will be returned as "undefined".
     if (!config) {
-        return undefined;
+        throw new Error(`Sorry, an email provider couldn't be found, Please use the manual connection.`);
     }
 
     const imapConfig: ImapConfig = {

--- a/src/core/imap.ts
+++ b/src/core/imap.ts
@@ -14,7 +14,7 @@ export class IMAP {
     private fromMonitoring: Query = null;
     private mailBoxMonitoring = null;
     private switcher = 1;
-    private delayTime = 1000 * 5;
+    private delayTime = 1000 * 60;
     private accountConfig: Imap.Config;
 
     // To check if there is a query not completed yet.

--- a/src/core/noteLocationBySubject.ts
+++ b/src/core/noteLocationBySubject.ts
@@ -184,8 +184,12 @@ export function noteLocationBySubject(s: string) {
     if (isRTL(s)) {
         s = wrapDir(s);
     }
-    const _folders = emailFolders(s);
+    let _folders = emailFolders(s);
     const _tags = emailTags(s);
+
+    if (_folders.length === 0) {
+        _folders = ['email messages'];
+    }
 
     return {folders: _folders, tags: _tags};
 }

--- a/src/core/noteLocationBySubject.ts
+++ b/src/core/noteLocationBySubject.ts
@@ -1,0 +1,228 @@
+// This regexs from https://github.com/regexhq/mentions-regex/blob/master/index.js
+const mentionPattern = /(?:^|[^a-zA-Z0-9_＠!@#$%&*])(?:(?:﹫|@|＠)(?!\/))([a-zA-Z0-9/_.]{1,50})(?:\b(?!﹫|@|＠|#|⋕|♯|⌗)|$)/g;
+const tagPattern = /(?:^|[^a-zA-Z0-9_＠!@#$%&*])(?:(?:#|⋕|♯|⌗)(?!\/))([a-zA-Z0-9/_.]{1,50})(?:\b(?!﹫|@|＠|#|⋕|♯|⌗)|$)/g;
+
+let keys: string[] = [];
+let nextKey = 0;
+
+// Generates (a-z, A-z)(0-9) = 26 * 10 * 2 unique keys for each character to convert the subject to (a-z, A-Z, 0-9) and apply regex on it.
+function generateKeys() {
+    keys = [];
+    nextKey = 0;
+
+    for (let c = 'A'.charCodeAt(0); c <= 'Z'.charCodeAt(0); c++) {
+        for (let i = 0; i < 10; i++) {
+            const key = String.fromCharCode(c) + i.toString();
+            keys.push(key);
+        }
+    }
+
+    for (let c = 'a'.charCodeAt(0); c <= 'z'.charCodeAt(0); c++) {
+        for (let i = 0; i < 10; i++) {
+            const key = String.fromCharCode(c) + i.toString();
+            keys.push(key);
+        }
+    }
+}
+
+function emailFolders(s: string) {
+    const alphaKey = new Map();
+    const alphaIndex = new Map();
+    const mentionSymbol = ['@', '＠', '﹫'];
+
+    let target = '';
+    const folders: string[] =[];
+
+    for (let i = 0; i < s.length; i++) {
+        if (mentionSymbol.includes(s[i])) {
+            alphaKey.set(s[i], s[i]);
+            alphaIndex.set(s[i], s[i]);
+            target += s[i];
+        } else if (s[i]=== ' ') {
+            target += ' ';
+        } else if (alphaKey.has(s[i])) {
+            target += alphaKey.get(s[i]);
+        } else {
+            alphaKey.set(s[i], keys[nextKey]);
+            alphaIndex.set(keys[nextKey], s[i]);
+            target += keys[nextKey];
+            nextKey++;
+        }
+    }
+
+    let m;
+    while (m = mentionPattern.exec(target)) {
+        let ans = '';
+        let key = '';
+        for (let i = 0; i < m[1].length; i += 2) {
+            key = m[1].substr(i, 2);
+
+            const mKey = alphaIndex.get(key);
+            ans += mKey;
+        }
+        folders.push(ans);
+    }
+
+    return folders;
+}
+
+function emailTags(s: string) {
+    const alphaKey = new Map();
+    const alphaIndex = new Map();
+    const tagsSymbol = ['#', '♯', '⌗', '⋕'];
+
+    let target = '';
+    const tags: string[] =[];
+
+    for (let i = 0; i < s.length; i++) {
+        if (tagsSymbol.includes(s[i])) {
+            alphaKey.set(s[i], s[i]);
+            alphaIndex.set(s[i], s[i]);
+            target += s[i];
+        } else if (s[i]=== ' ') {
+            target += ' ';
+        } else if (alphaKey.has(s[i])) {
+            target += alphaKey.get(s[i]);
+        } else {
+            alphaKey.set(s[i], keys[nextKey]);
+            alphaIndex.set(keys[nextKey], s[i]);
+            target += keys[nextKey];
+            nextKey++;
+        }
+    }
+
+    let m;
+    while (m = tagPattern.exec(target)) {
+        let ans = '';
+        let key = '';
+        for (let i = 0; i < m[1].length; i += 2) {
+            key = m[1].substr(i, 2);
+            const mKey = alphaIndex.get(key);
+            ans += mKey;
+        }
+        tags.push(ans);
+    }
+
+    return tags;
+}
+
+function isRTL(s: string) {
+    const rtlChars = '\u0591-\u07FF\u200F\u202B\u202E\uFB1D-\uFDFD\uFE70-\uFEFC';
+    const rtlDirCheck = new RegExp('^[^'+rtlChars+']*?['+rtlChars+']');
+    return rtlDirCheck.test(s);
+};
+
+function wrapDir(str: string) {
+    return '\u202B' + str + '\u202C';
+}
+
+// To remove irregular whitespace.
+// [Invisible Unicode characters](https://invisible-characters.com/#:~:text=Invisible%20Unicode%20characters%3F,%2B2800%20BRAILLE%20PATTERN%20BLANK).
+function removeInvisibleCharacters(s: string) {
+    return s.replace(/\u0009/g, ' ')
+        .replace(/\u0020/g, ' ')
+        .replace(/\u00A0/g, ' ')
+        .replace(/\u00AD/g, ' ')
+        .replace(/\u034F/g, ' ')
+        .replace(/\u061C/g, ' ')
+        .replace(/\u115F/g, ' ')
+        .replace(/\u1160/g, ' ')
+        .replace(/\u17B4/g, ' ')
+        .replace(/\u17B5/g, ' ')
+        .replace(/\u180E/g, ' ')
+        .replace(/\u2000/g, ' ')
+        .replace(/\u2001/g, ' ')
+        .replace(/\u2002/g, ' ')
+        .replace(/\u2003/g, ' ')
+        .replace(/\u2004/g, ' ')
+        .replace(/\u2005/g, ' ')
+        .replace(/\u2006/g, ' ')
+        .replace(/\u2007/g, ' ')
+        .replace(/\u2008/g, ' ')
+        .replace(/\u2009/g, ' ')
+        .replace(/\u200A/g, ' ')
+        .replace(/\u200B/g, ' ')
+        .replace(/\u200C/g, ' ')
+        .replace(/\u200D/g, ' ')
+        .replace(/\u200E/g, ' ')
+        .replace(/\u200F/g, ' ')
+        .replace(/\u202F/g, ' ')
+        .replace(/\u205F/g, ' ')
+        .replace(/\u2060/g, ' ')
+        .replace(/\u2061/g, ' ')
+        .replace(/\u2062/g, ' ')
+        .replace(/\u2063/g, ' ')
+        .replace(/\u2064/g, ' ')
+        .replace(/\u206A/g, ' ')
+        .replace(/\u206B/g, ' ')
+        .replace(/\u206C/g, ' ')
+        .replace(/\u206D/g, ' ')
+        .replace(/\u206E/g, ' ')
+        .replace(/\u206F/g, ' ')
+        .replace(/\u3000/g, ' ')
+        .replace(/\u2800/g, ' ')
+        .replace(/\u3164/g, ' ')
+        .replace(/\uFEFF/g, ' ')
+        .replace(/\uFFA0/g, ' ')
+        .replace(/\u1D159/g, ' ')
+        .replace(/\u1D173/g, ' ')
+        .replace(/\u1D174/g, ' ')
+        .replace(/\u1D175/g, ' ')
+        .replace(/\u1D176/g, ' ')
+        .replace(/\u1D177/g, ' ')
+        .replace(/\u1D177/g, ' ')
+        .replace(/\u1D179/g, ' ')
+        .replace(/\u1D17/g, ' ');
+}
+
+export function noteLocationBySubject(s: string) {
+    generateKeys();
+
+    // To avoid 'Non-breaking space'.
+    s = removeInvisibleCharacters(s);
+
+    if (isRTL(s)) {
+        s = wrapDir(s);
+    }
+    const _folders = emailFolders(s);
+    const _tags = emailTags(s);
+
+    return {folders: _folders, tags: _tags};
+}
+/*
+
+function search(s: string, targetSet: string[]) {
+    let temp = '';
+    let flag = false;
+    let noBoundery = true;
+    const folders: string[] = [];
+
+    for (let i = 0; i < s.length; i++) {
+        if ((s[i] === ' ' || i === 0 ) && !flag) {
+            noBoundery = true;
+        } else if (s[i]!== ' ' && !flag && !targetSet.includes(s[i])) {
+            noBoundery = false;
+        }
+
+        if (targetSet.includes(s[i]) && !flag && noBoundery) {
+            flag = true;
+        } else if (flag && s[i] !== ' ') {
+            temp += s[i];
+        } else if (s[i] === ' ' && flag && noBoundery) {
+            if (temp !== '') {
+                folders.push(temp);
+            }
+            flag = false;
+            noBoundery = false;
+            temp = '';
+            i--;
+        }
+    }
+
+    if (temp !== '') {
+        folders.push(temp);
+    }
+
+    return folders;
+}
+*/

--- a/src/core/noteLocationBySubject.ts
+++ b/src/core/noteLocationBySubject.ts
@@ -1,5 +1,8 @@
 // This regexs from https://github.com/regexhq/mentions-regex/blob/master/index.js
+// @folder regex Regular expression for matching @foldre mentions
 const mentionPattern = /(?:^|[^a-zA-Z0-9_＠!@#$%&*])(?:(?:﹫|@|＠)(?!\/))([a-zA-Z0-9/_.]{1,50})(?:\b(?!﹫|@|＠|#|⋕|♯|⌗)|$)/g;
+
+// #tag regex Regular expression for matching #tag mentions
 const tagPattern = /(?:^|[^a-zA-Z0-9_＠!@#$%&*])(?:(?:#|⋕|♯|⌗)(?!\/))([a-zA-Z0-9/_.]{1,50})(?:\b(?!﹫|@|＠|#|⋕|♯|⌗)|$)/g;
 
 let keys: string[] = [];
@@ -35,6 +38,7 @@ function emailFolders(s: string) {
 
     for (let i = 0; i < s.length; i++) {
         if (mentionSymbol.includes(s[i])) {
+            // Assign a key to each character in the string to be able to run the regex on different languages and Unicode characters.
             alphaKey.set(s[i], s[i]);
             alphaIndex.set(s[i], s[i]);
             target += s[i];
@@ -51,12 +55,15 @@ function emailFolders(s: string) {
     }
 
     let m;
+
+    // to extract all matches from the string.
     while (m = mentionPattern.exec(target)) {
         let ans = '';
         let key = '';
         for (let i = 0; i < m[1].length; i += 2) {
             key = m[1].substr(i, 2);
 
+            // Return the original character from the string
             const mKey = alphaIndex.get(key);
             ans += mKey;
         }
@@ -76,6 +83,7 @@ function emailTags(s: string) {
 
     for (let i = 0; i < s.length; i++) {
         if (tagsSymbol.includes(s[i])) {
+            // Assign a key to each character in the string to be able to run the regex on different languages and Unicode characters.
             alphaKey.set(s[i], s[i]);
             alphaIndex.set(s[i], s[i]);
             target += s[i];
@@ -92,11 +100,15 @@ function emailTags(s: string) {
     }
 
     let m;
+
+    // to extract all matches from the string.
     while (m = tagPattern.exec(target)) {
         let ans = '';
         let key = '';
         for (let i = 0; i < m[1].length; i += 2) {
             key = m[1].substr(i, 2);
+
+            // Return the original character from the string
             const mKey = alphaIndex.get(key);
             ans += mKey;
         }
@@ -106,6 +118,7 @@ function emailTags(s: string) {
     return tags;
 }
 
+// To check whether the string line is RTL language or not.
 function isRTL(s: string) {
     const rtlChars = '\u0591-\u07FF\u200F\u202B\u202E\uFB1D-\uFDFD\uFE70-\uFEFC';
     const rtlDirCheck = new RegExp('^[^'+rtlChars+']*?['+rtlChars+']');
@@ -176,7 +189,12 @@ function removeInvisibleCharacters(s: string) {
 }
 
 export function noteLocationBySubject(s: string) {
-    generateKeys();
+    if (keys.length) {
+        // reset index
+        nextKey = 0;
+    } else {
+        generateKeys();
+    }
 
     // To avoid 'Non-breaking space'.
     s = removeInvisibleCharacters(s);
@@ -187,6 +205,7 @@ export function noteLocationBySubject(s: string) {
     let _folders = emailFolders(s);
     const _tags = emailTags(s);
 
+    // If no folder is mentioned, it will locate the note in the 'email messages' folder.
     if (_folders.length === 0) {
         _folders = ['email messages'];
     }

--- a/src/core/noteLocationBySubject.ts
+++ b/src/core/noteLocationBySubject.ts
@@ -203,49 +203,18 @@ export function noteLocationBySubject(s: string) {
         s = wrapDir(s);
     }
     let _folders = emailFolders(s);
-    const _tags = emailTags(s);
+    let _tags = emailTags(s);
 
     // If no folder is mentioned, it will locate the note in the 'email messages' folder.
     if (_folders.length === 0) {
         _folders = ['email messages'];
+    } else {
+        // To lowercase all tags to avoid overwriting the same tag again.
+        _tags = _tags.map((e)=>e.toLowerCase());
+
+        // To remove duplicate tags in the same note.
+        _tags = [...new Set(_tags)];
     }
 
     return {folders: _folders, tags: _tags};
 }
-/*
-
-function search(s: string, targetSet: string[]) {
-    let temp = '';
-    let flag = false;
-    let noBoundery = true;
-    const folders: string[] = [];
-
-    for (let i = 0; i < s.length; i++) {
-        if ((s[i] === ' ' || i === 0 ) && !flag) {
-            noBoundery = true;
-        } else if (s[i]!== ' ' && !flag && !targetSet.includes(s[i])) {
-            noBoundery = false;
-        }
-
-        if (targetSet.includes(s[i]) && !flag && noBoundery) {
-            flag = true;
-        } else if (flag && s[i] !== ' ') {
-            temp += s[i];
-        } else if (s[i] === ' ' && flag && noBoundery) {
-            if (temp !== '') {
-                folders.push(temp);
-            }
-            flag = false;
-            noBoundery = false;
-            temp = '';
-            i--;
-        }
-    }
-
-    if (temp !== '') {
-        folders.push(temp);
-    }
-
-    return folders;
-}
-*/

--- a/src/core/postAttachments.ts
+++ b/src/core/postAttachments.ts
@@ -18,46 +18,13 @@ export class Attachments {
         const attachmentsProp: AttachmentProperties[] = [];
         const tempFolder = this.tempFolderPath;
 
-        try {
-            // for each attachment will create an actual file of the attachment and posting to Joplin.
-            for (let i = 0; i < this.attachments.length; i++) {
-                const {contentId, filename, mimeType} = this.attachments[i];
-                const filePath = path.join(tempFolder, this.attachments[i].filename);
-
-                // to create a file
-                fs.writeFileSync(filePath, Buffer.from(this.attachments[i].content));
-
-                // To post a file to Joplin
-                const resource = await joplin.data.post(
-                    ['resources'],
-                    null,
-                    {title: filename}, // Resource metadata
-                    [
-                        {
-                            path: filePath, // Actual file
-                        },
-                    ],
-                );
-
-                attachmentsProp.push({contentId: contentId, id: resource.id, fileName: filename, mimeType: mimeType});
-            }
-
-            return attachmentsProp;
-        } catch (err) {
-            throw err;
-        }
-    }
-
-    async postInlineAttachment(attachment: Attachment): Promise<AttachmentProperties> {
-        const tempFolder = this.tempFolderPath;
-
-        try {
-            // for each attachment will create an actual file of the attachment and posting to Joplin.
-            const {contentId, filename, mimeType, content} = attachment;
-            const path = `${tempFolder}${filename}`;
+        // for each attachment will create an actual file of the attachment and posting to Joplin.
+        for (let i = 0; i < this.attachments.length; i++) {
+            const {contentId, filename, mimeType} = this.attachments[i];
+            const filePath = path.join(tempFolder, this.attachments[i].filename);
 
             // to create a file
-            fs.writeFileSync(path, Buffer.from(content));
+            fs.writeFileSync(filePath, Buffer.from(this.attachments[i].content));
 
             // To post a file to Joplin
             const resource = await joplin.data.post(
@@ -66,15 +33,39 @@ export class Attachments {
                 {title: filename}, // Resource metadata
                 [
                     {
-                        path: path, // Actual file
+                        path: filePath, // Actual file
                     },
                 ],
             );
-
-            return {contentId: contentId, id: resource.id, fileName: filename, mimeType: mimeType};
-        } catch (err) {
-            throw err;
+            attachmentsProp.push({contentId: contentId, id: resource.id, fileName: filename, mimeType: mimeType});
         }
+
+        return attachmentsProp;
+    }
+
+    async postInlineAttachment(attachment: Attachment): Promise<AttachmentProperties> {
+        const tempFolder = this.tempFolderPath;
+
+        // Will create an actual file of the attachment and post it to Joplin.
+        const {contentId, filename, mimeType, content} = attachment;
+        const path = `${tempFolder}${filename}`;
+
+        // to create a file
+        fs.writeFileSync(path, Buffer.from(content));
+
+        // To post a file to Joplin
+        const resource = await joplin.data.post(
+            ['resources'],
+            null,
+            {title: filename}, // Resource metadata
+            [
+                {
+                    path: path, // Actual file
+                },
+            ],
+        );
+
+        return {contentId: contentId, id: resource.id, fileName: filename, mimeType: mimeType};
     }
 }
 

--- a/src/core/postAttachments.ts
+++ b/src/core/postAttachments.ts
@@ -48,10 +48,10 @@ export class Attachments {
 
         // Will create an actual file of the attachment and post it to Joplin.
         const {contentId, filename, mimeType, content} = attachment;
-        const path = `${tempFolder}${filename}`;
+        const filePath = path.join(tempFolder, filename);
 
         // to create a file
-        fs.writeFileSync(path, Buffer.from(content));
+        fs.writeFileSync(filePath, Buffer.from(content));
 
         // To post a file to Joplin
         const resource = await joplin.data.post(
@@ -60,7 +60,7 @@ export class Attachments {
             {title: filename}, // Resource metadata
             [
                 {
-                    path: path, // Actual file
+                    path: filePath, // Actual file
                 },
             ],
         );

--- a/src/core/postAttachments.ts
+++ b/src/core/postAttachments.ts
@@ -48,7 +48,7 @@ export class Attachments {
         }
     }
 
-    async postAttachment(attachment: Attachment): Promise<AttachmentProperties> {
+    async postInlineAttachment(attachment: Attachment): Promise<AttachmentProperties> {
         const tempFolder = this.tempFolderPath;
 
         try {

--- a/src/core/postAttachments.ts
+++ b/src/core/postAttachments.ts
@@ -21,7 +21,7 @@ export class Attachments {
         try {
             // for each attachment will create an actual file of the attachment and posting to Joplin.
             for (let i = 0; i < this.attachments.length; i++) {
-                const {contentId, filename} = this.attachments[i];
+                const {contentId, filename, mimeType} = this.attachments[i];
                 const filePath = path.join(tempFolder, this.attachments[i].filename);
 
                 // to create a file
@@ -39,10 +39,39 @@ export class Attachments {
                     ],
                 );
 
-                attachmentsProp.push({contentId: contentId, id: resource.id});
+                attachmentsProp.push({contentId: contentId, id: resource.id, fileName: filename, mimeType: mimeType});
             }
 
             return attachmentsProp;
+        } catch (err) {
+            throw err;
+        }
+    }
+
+    async postAttachment(attachment: Attachment): Promise<AttachmentProperties> {
+        const tempFolder = this.tempFolderPath;
+
+        try {
+            // for each attachment will create an actual file of the attachment and posting to Joplin.
+            const {contentId, filename, mimeType, content} = attachment;
+            const path = `${tempFolder}${filename}`;
+
+            // to create a file
+            fs.writeFileSync(path, Buffer.from(content));
+
+            // To post a file to Joplin
+            const resource = await joplin.data.post(
+                ['resources'],
+                null,
+                {title: filename}, // Resource metadata
+                [
+                    {
+                        path: path, // Actual file
+                    },
+                ],
+            );
+
+            return {contentId: contentId, id: resource.id, fileName: filename, mimeType: mimeType};
         } catch (err) {
             throw err;
         }

--- a/src/core/postNote.ts
+++ b/src/core/postNote.ts
@@ -194,7 +194,7 @@ export class PostNote {
         this.emailHtmlBody = dom.body.innerHTML;
     }
 
-    async addAttachments(attachmentsStyle: 'Tabel' | 'Link'): Promise<string> {
+    async addAttachments(attachmentsStyle: 'Table' | 'Link'): Promise<string> {
         const postAttachments = new Attachments(this.attachments, this.tempFolderPath);
         const attachmentsProp: AttachmentProperties[] = await postAttachments.postAttachments();
 

--- a/src/core/postNote.ts
+++ b/src/core/postNote.ts
@@ -1,11 +1,13 @@
 import joplin from 'api';
 import {Attachment} from '../model/attachment.model';
-import {EmailContent} from '../model/emailContent.model';
-import {EXPORT_TYPE} from '../constants';
 import {Attachments} from './postAttachments';
-import {ExportNote} from '../model/exportNote.model';
+import {Note} from '../model/note.model';
 import {AttachmentProperties} from 'src/model/attachmentProperties.model';
 import {Tag} from '../model/tag.model';
+import {ExportCriteria} from '../model/exportCriteria.model';
+import {noteLocationBySubject} from './noteLocationBySubject';
+import {isPostByFolderId, isPostBySubject, PostCriteria} from '../model/postCriteria.model';
+import {convert as htmlToText} from 'html-to-text';
 
 export class PostNote {
     emailHtmlBody: string;
@@ -13,14 +15,42 @@ export class PostNote {
     tempFolderPath: string;
     attachments: Attachment[];
     folders: string[] = [];
-    note: ExportNote = {title: '', parent_id: '', body: '', body_html: '', markup_language: 1};
+    note: Note = {title: null, parent_id: null, body: null, body_html: null, markup_language: null};
 
     async createFolder(folder: string): Promise<void> {
-        await joplin.data.post(['folders'], null, {title: folder});
+        return await joplin.data.post(['folders'], null, {title: folder});
     }
 
     async createTag(tag: string): Promise<Tag> {
         return await joplin.data.post(['tags'], null, {title: tag});
+    }
+
+    async addFolders(folders: string[]): Promise<any[]> {
+        let joplinFolders : {items: any[], has_more: boolean};
+        let page = 1;
+        // copy of tags
+        const tempFolders = [...folders];
+        const emailFolders: any[] = [];
+
+        do {
+            joplinFolders = await joplin.data.get(['folders'], {page: page++});
+
+            for (let i = 0; i < joplinFolders.items.length; i++) {
+                const joplinFolder: any = joplinFolders.items[i];
+
+                if (tempFolders.includes(joplinFolder.title)) {
+                    emailFolders.push(joplinFolder);
+                    const index = tempFolders.indexOf(joplinFolder.title);
+                    tempFolders.splice(index, 1);
+                }
+            }
+        } while (joplinFolders.has_more);
+
+        for (let i = 0; i < tempFolders.length; i++) {
+            const folder: any = await this.createFolder(tempFolders[i]);
+            emailFolders.push(folder);
+        }
+        return emailFolders;
     }
 
     async addTags(tags: string[]): Promise<Tag[]> {
@@ -52,52 +82,71 @@ export class PostNote {
         return emailTags;
     }
 
-    async post(emailContent: EmailContent, tempFolderPath: string, folderId: string, tags: string []): Promise<void> {
-        this.attachments = emailContent.attachments;
-        this.subject = emailContent.subject;
-        this.tempFolderPath = tempFolderPath;
-        this.note['parent_id'] = folderId;
-
-        // to get only the HTML body of the email and ignore unnecessary data.
-        this.emailHtmlBody = new DOMParser().parseFromString(emailContent.html, 'text/html').body.innerHTML;
+    async post(postCriteria: PostCriteria): Promise<void> {
+        this.attachments = postCriteria['emailContent'].attachments;
+        this.subject = postCriteria['emailContent'].subject;
+        this.emailHtmlBody = postCriteria['emailContent'].html;
+        this.tempFolderPath = postCriteria['tempFolderPath'];
+        let emailTags = [];
+        let emailFolders = [];
 
         // Converting email to (html, markdown, text) depends on what export type is in the plugin settings.
-        await this.convert();
+        await this.convert(postCriteria['exportCriteria']);
 
-        const emailTags = await this.addTags(tags);
+        if (isPostByFolderId(postCriteria)) {
+            this.note['parent_id'] = postCriteria['folderId'];
+            emailTags = await this.addTags(postCriteria['tags']);
 
-        // Post the note to Joplin.
-        const note = await joplin.data.post(['notes'], null, this.note);
+            // Post the note to Joplin.
+            const note = await joplin.data.post(['notes'], null, this.note);
 
-        // assign the tags for the note.
-        for (let j = 0; j < emailTags.length; j++) {
-            const tag = emailTags[j];
-            await joplin.data.post(['tags', tag.id, 'notes'], null, {id: note.id});
+            // assign the tags for the note.
+            for (let j = 0; j < emailTags.length; j++) {
+                const tag = emailTags[j];
+                await joplin.data.post(['tags', tag.id, 'notes'], null, {id: note.id});
+            }
+        } else if (isPostBySubject(postCriteria)) {
+            const subject = postCriteria['emailContent'].subject;
+            const emailText = htmlToText(this.emailHtmlBody, {wordwrap: 130, selectors: [{selector: 'img', format: 'skip'}]});
+            const firstLine = (emailText || '').trim().split('\n')[0];
+            const {folders, tags} = noteLocationBySubject(subject + ' ' + firstLine);
+
+            emailTags = await this.addTags(tags);
+            emailFolders = await this.addFolders(folders);
+
+            for (let i = 0; i < emailFolders.length; i++) {
+                this.note['parent_id'] = emailFolders[i].id;
+                const note = await joplin.data.post(['notes'], null, this.note);
+
+                for (let j = 0; j < emailTags.length; j++) {
+                    const tag = emailTags[j];
+                    await joplin.data.post(['tags', tag.id, 'notes'], null, {id: note.id});
+                }
+            }
         }
     }
 
+    async convert(exportNote: ExportCriteria): Promise<void> {
+        // to get only the HTML body of the email and ignore unnecessary data.
+        this.emailHtmlBody = new DOMParser().parseFromString(this.emailHtmlBody, 'text/html').body.innerHTML;
 
-    async convert() {
-        const exportType = await joplin.settings.value(EXPORT_TYPE);
+        const attachmentsLinks = exportNote['includeAttachments']? await this.addAttachments(exportNote['attachmentsStyle']): '';
+        const {exportType} = exportNote;
+
         if (exportType === 'HTML') {
-            const postAttachments = new Attachments(this.attachments, this.tempFolderPath);
-            const attachmentsProp: AttachmentProperties[] = await postAttachments.postAttachments();
-
             // Replace each attachment img src with the ID of the attachment location in Joplin resources.
-            await this.addInlineAttachments(attachmentsProp);
+            await this.addInlineAttachments();
 
             this.note['title'] = this.subject;
-            this.note['body'] = this.emailHtmlBody;
+            this.note['body'] = this.emailHtmlBody + attachmentsLinks;
             this.note['markup_language'] = 2;
         } else if (exportType === 'Markdown') {
-            const postAttachments = new Attachments(this.attachments, this.tempFolderPath);
-            const attachmentsProp: AttachmentProperties[] = await postAttachments.postAttachments();
-
             // Replace each attachment img src with the ID of the attachment location in Joplin resources.
-            await this.addInlineAttachments(attachmentsProp);
+            await this.addInlineAttachments();
 
             this.note['title'] = this.subject;
-            this.note['body_html'] = this.emailHtmlBody;
+            this.note['body_html'] = this.emailHtmlBody + attachmentsLinks;
+            this.note['markup_language'] = 1;
         } else if (exportType === 'Text') {
             this.note['title'] = this.subject;
 
@@ -109,25 +158,67 @@ export class PostNote {
             while (images.length > 0) {
                 images[0].parentNode.removeChild(images[0]);
             }
-            this.note['body_html'] = dom.body.innerHTML;
+
+            const htmlToText = dom.body.innerHTML
+                .replace(/<\/?(table|tr|td|th)\b[^>]*>/gi, '\n\n')
+                .replace(/\r?\n/g, '\u0001')
+
+                // convert linebreak placeholders back to newlines
+                .replace(/\u0001/g, '\n');
+
+            this.note['body_html'] = htmlToText + attachmentsLinks;
+            this.note['markup_language'] = 1;
         }
     }
 
-    async addInlineAttachments(attachmentsProp: AttachmentProperties[]) {
+    async addInlineAttachments(): Promise<void> {
         const domParser = new DOMParser();
         const dom: Document = domParser.parseFromString(this.emailHtmlBody, 'text/html');
+        const imgs = dom.body.querySelectorAll('img');
+        const postAttachments = new Attachments(this.attachments, this.tempFolderPath);
 
-        dom.body.querySelectorAll('img').forEach((img)=>{
+        for (let i = 0; i < imgs.length; i++) {
+            const img = imgs[i];
+
             // replace with inline attachment.
             if (/^cid:/.test(img.src)) {
                 const cid = img.src.substr(4).trim();
-                const attachment = attachmentsProp.find((attachment)=>attachment.contentId && attachment.contentId === `<${cid}>`);
+                const attachment = this.attachments.find((attachment)=>attachment.contentId && attachment.contentId === `<${cid}>`);
+
                 if (attachment) {
-                    img.src = `:/${attachment.id}`;
+                    const resource = await postAttachments.postAttachment(attachment);
+                    img.src = `:/${resource.id}`;
                 }
             }
-        });
+        };
         this.emailHtmlBody = dom.body.innerHTML;
     }
-}
 
+    async addAttachments(attachmentsStyle: string): Promise<string> {
+        const postAttachments = new Attachments(this.attachments, this.tempFolderPath);
+        const attachmentsProp: AttachmentProperties[] = await postAttachments.postAttachments();
+
+        let attachments: string ='';
+        let attachmentsLinks: string = '';
+
+        if (attachmentsStyle === 'Link') {
+            attachmentsProp.forEach((att)=>{
+                const link = `<a href = ":/${att.id}">${att.fileName} </a> <br>`;
+                attachments += link;
+            });
+            attachmentsLinks = attachments !== ''? `<h2>Attachments</h2>${attachments}` : '';
+        } else {
+            attachmentsProp.forEach((att)=>{
+                if (att.mimeType.startsWith('image/')) {
+                    const link = `<tr><td>${att.fileName}</td><td> <img src=":/${att.id}" alt = "${att.fileName}" style="max-width:100%; max-height:100%;"> </td></tr>`;
+                    attachments+= link;
+                } else {
+                    const link =`<tr><td>${att.fileName}</td><td> <a href=":/${att.id}">${att.fileName}</a> </td></tr>`;
+                    attachments+= link;
+                }
+            });
+            attachmentsLinks = attachments !== ''? `<h2>Attachments</h2><table style = "width:100%;"><tr><th>Filename</th><th>Link</th></tr>${attachments}</table>`: '';
+        }
+        return attachmentsLinks;
+    }
+}

--- a/src/core/postNote.ts
+++ b/src/core/postNote.ts
@@ -186,7 +186,7 @@ export class PostNote {
                 const attachment = this.attachments.find((attachment)=>attachment.contentId && attachment.contentId === `<${cid}>`);
 
                 if (attachment) {
-                    const resource = await postAttachments.postAttachment(attachment);
+                    const resource = await postAttachments.postInlineAttachment(attachment);
                     img.src = `:/${resource.id}`;
                 }
             }

--- a/src/core/postNote.ts
+++ b/src/core/postNote.ts
@@ -135,14 +135,14 @@ export class PostNote {
 
         if (exportType === 'HTML') {
             // Replace each attachment img src with the ID of the attachment location in Joplin resources.
-            await this.addInlineAttachments();
+            await this.addInlineImages();
 
             this.note['title'] = this.subject;
             this.note['body'] = this.emailHtmlBody + attachmentsLinks;
             this.note['markup_language'] = 2;
         } else if (exportType === 'Markdown') {
             // Replace each attachment img src with the ID of the attachment location in Joplin resources.
-            await this.addInlineAttachments();
+            await this.addInlineImages();
 
             this.note['title'] = this.subject;
             this.note['body_html'] = this.emailHtmlBody + attachmentsLinks;
@@ -171,7 +171,7 @@ export class PostNote {
         }
     }
 
-    async addInlineAttachments(): Promise<void> {
+    async addInlineImages(): Promise<void> {
         const domParser = new DOMParser();
         const dom: Document = domParser.parseFromString(this.emailHtmlBody, 'text/html');
         const imgs = dom.body.querySelectorAll('img');

--- a/src/core/postNote.ts
+++ b/src/core/postNote.ts
@@ -194,7 +194,7 @@ export class PostNote {
         this.emailHtmlBody = dom.body.innerHTML;
     }
 
-    async addAttachments(attachmentsStyle: string): Promise<string> {
+    async addAttachments(attachmentsStyle: 'Tabel' | 'Link'): Promise<string> {
         const postAttachments = new Attachments(this.attachments, this.tempFolderPath);
         const attachmentsProp: AttachmentProperties[] = await postAttachments.postAttachments();
 

--- a/src/core/setupTempFolder.ts
+++ b/src/core/setupTempFolder.ts
@@ -5,20 +5,17 @@ const fs = joplin.require('fs-extra');
 
 
 export class SetupTempFolder {
-    tempFolder: string;
-    constructor() {
-        this.tempFolder = path.join(tmpdir(), 'joplin-email-plugin');
+    static tempFolder = path.join(tmpdir(), 'joplin-email-plugin');
+
+    static get tempFolderPath() {
+        return SetupTempFolder.tempFolder;
     }
 
-    get tempFolderPath() {
-        return this.tempFolder;
+    static createTempFolder() {
+        fs.mkdirSync(SetupTempFolder.tempFolder, {recursive: true});
     }
 
-    createTempFolder() {
-        fs.mkdirSync(this.tempFolder, {recursive: true});
-    }
-
-    removeTempFolder() {
-        fs.rmdirSync(this.tempFolder, {recursive: true});
+    static removeTempFolder() {
+        fs.rmdirSync(SetupTempFolder.tempFolder, {recursive: true});
     }
 }

--- a/src/model/account.model.ts
+++ b/src/model/account.model.ts
@@ -1,0 +1,5 @@
+import {Config} from 'imap';
+
+export interface Account{
+    'email': Config
+}

--- a/src/model/attachmentProperties.model.ts
+++ b/src/model/attachmentProperties.model.ts
@@ -2,4 +2,6 @@
 export interface AttachmentProperties{
     contentId: string,
     id: string,
+    fileName: string,
+    mimeType: string
 }

--- a/src/model/exportCriteria.model.ts
+++ b/src/model/exportCriteria.model.ts
@@ -1,5 +1,5 @@
 export interface ExportCriteria{
     exportType: 'HTML' | 'Markdown' | 'Text',
     includeAttachments: boolean,
-    attachmentsStyle: 'Tabel' | 'Link'
+    attachmentsStyle: 'Table' | 'Link'
 }

--- a/src/model/exportCriteria.model.ts
+++ b/src/model/exportCriteria.model.ts
@@ -1,0 +1,5 @@
+export interface ExportCriteria{
+    exportType: 'HTML' | 'Markdown' | 'Text',
+    includeAttachments: boolean,
+    attachmentsStyle: 'Tabel' | 'Link'
+}

--- a/src/model/message.model.ts
+++ b/src/model/message.model.ts
@@ -23,30 +23,30 @@ export function isHide(message: any): message is Hide {
 
 
 export interface ManualConnectionScreen {
-    manual_connection_screen: boolean
+    manualConnectionScreen: boolean
 }
 
 // Type predicates
 export function isManualConnectionScreen(message: any): message is ManualConnectionScreen {
-    return 'manual_connection_screen' in message;
+    return 'manualConnectionScreen' in message;
 }
 
 export interface LoginScreen {
-    login_screen: boolean
+    loginScreen: boolean
 }
 
 // Type predicates
 export function isLoginScreen(message: any): message is LoginScreen {
-    return 'login_screen' in message;
+    return 'loginScreen' in message;
 }
 
 export interface LoginManually extends ImapConfig {
-    login_manually: boolean,
+    loginManually: boolean,
 }
 
 // Type predicates
 export function isLoginManually(message: any): message is LoginManually {
-    return 'login_manually' in message && 'user' in message && 'password' in message &&
+    return 'loginManually' in message && 'user' in message && 'password' in message &&
         'host' in message && 'port' in message && 'tls' in message;
 }
 
@@ -65,12 +65,12 @@ export function isMonitorEmail(message: any): message is SearchByFrom {
 }
 
 export interface UploadMessagesScreen{
-    upload_messages_screen: boolean,
+    uploadMessagesScreen: boolean,
 }
 
 // Type predicates
 export function isUploadMessagesScreen(message: any): message is UploadMessagesScreen {
-    return 'upload_messages_screen' in message;
+    return 'uploadMessagesScreen' in message;
 }
 
 export interface EMLtoNote{

--- a/src/model/message.model.ts
+++ b/src/model/message.model.ts
@@ -79,7 +79,7 @@ export interface EMLtoNote{
     tags: string[],
     exportType: 'HTML' | 'Markdown' | 'Text',
     includeAttachments: boolean,
-    attachmentsStyle: 'Tabel' | 'Link',
+    attachmentsStyle: 'Table' | 'Link',
 }
 
 // Type predicates

--- a/src/model/message.model.ts
+++ b/src/model/message.model.ts
@@ -116,14 +116,14 @@ export function isMonitorMailBox(message: any): message is MonitorMailBox {
     return 'monitorMailBox' in message;
 }
 
-export interface RememberMe{
-    rememberMe: boolean,
+export interface Refresh{
+    refresh: boolean,
 
 }
 
 // Type predicates
-export function isRemeberMe(message: any): message is RememberMe {
-    return 'rememberMe' in message;
+export function isRefresh(message: any): message is Refresh {
+    return 'refresh' in message;
 }
 
-export type Message = Login | ManualConnectionScreen | Hide | LoginScreen | LoginManually | SearchByFrom | UploadMessagesScreen | EMLtoNote | Logout | SelectAccount | MonitorMailBox | RememberMe;
+export type Message = Login | ManualConnectionScreen | Hide | LoginScreen | LoginManually | SearchByFrom | UploadMessagesScreen | EMLtoNote | Logout | SelectAccount | MonitorMailBox | Refresh;

--- a/src/model/message.model.ts
+++ b/src/model/message.model.ts
@@ -1,3 +1,4 @@
+import {Config} from 'imap';
 import {ImapConfig} from './imapConfig.model';
 
 export interface Login {
@@ -21,13 +22,13 @@ export function isHide(message: any): message is Hide {
 }
 
 
-export interface ManualConnection {
-    manual_connection: boolean
+export interface ManualConnectionScreen {
+    manual_connection_screen: boolean
 }
 
 // Type predicates
-export function isManualConnection(message: any): message is ManualConnection {
-    return 'manual_connection' in message;
+export function isManualConnectionScreen(message: any): message is ManualConnectionScreen {
+    return 'manual_connection_screen' in message;
 }
 
 export interface LoginScreen {
@@ -55,7 +56,7 @@ export interface SearchByFrom {
 }
 
 // Type predicates
-export function isSearchByFrom(message: any): message is SearchByFrom {
+export function isMonitorEmail(message: any): message is SearchByFrom {
     if (message.state === 'close') {
         return 'state' in message && 'from' in message;
     } else {
@@ -63,24 +64,66 @@ export function isSearchByFrom(message: any): message is SearchByFrom {
     }
 }
 
-export interface UploadMessages{
-    upload_messages: boolean,
+export interface UploadMessagesScreen{
+    upload_messages_screen: boolean,
 }
 
 // Type predicates
-export function isUploadMessages(message: any): message is UploadMessages {
-    return 'upload_messages' in message;
+export function isUploadMessagesScreen(message: any): message is UploadMessagesScreen {
+    return 'upload_messages_screen' in message;
 }
 
 export interface EMLtoNote{
     emlFiles: string[],
     folderId: string,
     tags: string[],
+    exportType: 'HTML' | 'Markdown' | 'Text',
+    includeAttachments: boolean,
+    attachmentsStyle: 'Tabel' | 'Link',
 }
 
 // Type predicates
-export function isEMLtoNote(message: any): message is EMLtoNote {
-    return 'emlFiles' in message && 'folderId' in message && 'tags' in message;
+export function isUploadMessages(message: any): message is EMLtoNote {
+    return 'emlFiles' in message && 'folderId' in message && 'tags' in message && 'exportType' in message && 'includeAttachments' in message && 'attachmentsStyle' in message;
 }
 
-export type Message = Login | ManualConnection | Hide | LoginScreen | LoginManually | SearchByFrom | UploadMessages | EMLtoNote;
+export interface Logout{
+    logout: boolean
+}
+
+// Type predicates
+export function isLogout(message: any): message is Logout {
+    return 'logout' in message;
+}
+
+export interface SelectAccount{
+    account: Config
+}
+
+// Type predicates
+export function isSelectAccount(message: any): message is SelectAccount {
+    return 'account' in message;
+}
+
+export interface MonitorMailBox{
+    monitorMailBox: boolean,
+    mailbox?: string,
+    folderId?: string,
+}
+
+// Type predicates
+export function isMonitorMailBox(message: any): message is MonitorMailBox {
+    return 'monitorMailBox' in message;
+}
+
+export interface RememberMe{
+    rememberMe: boolean,
+
+}
+
+// Type predicates
+export function isRemeberMe(message: any): message is RememberMe {
+    return 'rememberMe' in message;
+}
+
+export type Message = Login | ManualConnectionScreen | Hide | LoginScreen | LoginManually | SearchByFrom | UploadMessagesScreen | EMLtoNote | Logout | SelectAccount | MonitorMailBox | RememberMe;

--- a/src/model/note.model.ts
+++ b/src/model/note.model.ts
@@ -1,0 +1,7 @@
+export interface Note{
+    title: string,
+    parent_id:string,
+    body?: string,
+    body_html?: string,
+    markup_language: number
+}

--- a/src/model/postCriteria.model.ts
+++ b/src/model/postCriteria.model.ts
@@ -1,0 +1,18 @@
+import {EmailContent} from './emailContent.model';
+import {ExportCriteria} from './exportCriteria.model';
+
+export interface PostCriteria{
+    emailContent: EmailContent,
+    exportCriteria: ExportCriteria,
+    tempFolderPath: string,
+    folderId?: string,
+    tags?: string[],
+}
+
+export function isPostBySubject(postCriteria: PostCriteria) {
+    return 'emailContent' in postCriteria && 'exportCriteria' in postCriteria && 'tempFolderPath' in postCriteria && Object.keys(postCriteria).length === 3;
+}
+
+export function isPostByFolderId(postCriteria: PostCriteria) {
+    return 'emailContent' in postCriteria && 'exportCriteria' in postCriteria && 'tempFolderPath' in postCriteria && 'folderId' in postCriteria && 'tags' in postCriteria;
+}

--- a/src/model/state.model.ts
+++ b/src/model/state.model.ts
@@ -1,0 +1,11 @@
+import {Config} from 'imap';
+
+export interface State{
+    accountConfig: Config,
+    from: string,
+    isFromMonitor: boolean,
+    mailBox: string,
+    mailBoxes: {path: string, value: string}[],
+    isMailBoxMonitor: boolean,
+    folderId: string,
+}

--- a/src/model/state.model.ts
+++ b/src/model/state.model.ts
@@ -3,9 +3,9 @@ import {Config} from 'imap';
 export interface State{
     accountConfig: Config,
     from: string,
-    isFromMonitor: boolean,
+    isEmailMonitor: boolean,
+    isMailBoxMonitor: boolean,
     mailBox: string,
     mailBoxes: {path: string, value: string}[],
-    isMailBoxMonitor: boolean,
     folderId: string,
 }

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -27,14 +27,14 @@ export const setting = {
     },
 
     [ATTACHMENTS_STYLE]: {
-        value: 'Tabel',
+        value: 'Table',
         type: SettingItemType.String,
         section: SECTION_NAME,
         isEnum: true,
         public: true,
         label: 'Attachments Style',
         options: {
-            'Tabel': 'Tabel',
+            'Table': 'Table',
             'Link': 'Link',
         },
         description: 'Note: Table Style displays images and videos in the note.',

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -1,19 +1,19 @@
 import {SettingItemType} from 'api/types';
-import {SECTION_NAME, EXPORT_TYPE, ATTACHMENTS} from './constants';
+import {SECTION_NAME, EXPORT_TYPE, ATTACHMENTS, ATTACHMENTS_STYLE, ACCOUNTS, LAST_STATE} from './constants';
 
 export const setting = {
 
     [EXPORT_TYPE]: {
-        value: 'Markdown',
+        value: 'HTML',
         type: SettingItemType.String,
         section: SECTION_NAME,
         isEnum: true,
         public: true,
         label: 'Export Type',
         options: {
+            'HTML': 'HTML',
             'Markdown': 'Markdown',
             'Text': 'Text',
-            'HTML': 'HTML',
         },
     },
 
@@ -24,6 +24,38 @@ export const setting = {
         public: true,
         label: 'Include Attachments',
 
+    },
+
+    [ATTACHMENTS_STYLE]: {
+        value: 'Tabel',
+        type: SettingItemType.String,
+        section: SECTION_NAME,
+        isEnum: true,
+        public: true,
+        label: 'Attachments Style',
+        options: {
+            'Tabel': 'Tabel',
+            'Link': 'Link',
+        },
+        description: 'Note: Table Style displays images and videos in the note.',
+    },
+
+    [ACCOUNTS]: {
+        value: {},
+        type: SettingItemType.Object,
+        section: SECTION_NAME,
+        secure: true,
+        public: true,
+        label: 'Accounts',
+    },
+
+    [LAST_STATE]: {
+        value: {},
+        type: SettingItemType.Object,
+        section: SECTION_NAME,
+        secure: true,
+        public: true,
+        label: 'Last_State',
     },
 
 };

--- a/src/ui/panel.ts
+++ b/src/ui/panel.ts
@@ -1,6 +1,6 @@
 import joplin from 'api';
 import JoplinViewsPanels from 'api/JoplinViewsPanels';
-import {Message, Login, isLogin, isHide, isManualConnectionScreen, isLoginScreen, isLoginManually, isMonitorEmail, SearchByFrom, isUploadMessagesScreen, isUploadMessages, EMLtoNote, isLogout, isSelectAccount, SelectAccount, isMonitorMailBox, MonitorMailBox} from '../model/message.model';
+import {Message, Login, isLogin, isHide, isManualConnectionScreen, isLoginScreen, isLoginManually, isMonitorEmail, SearchByFrom, isUploadMessagesScreen, isUploadMessages, EMLtoNote, isLogout, isSelectAccount, SelectAccount, isMonitorMailBox, MonitorMailBox, isRefresh} from '../model/message.model';
 import {ImapConfig} from '../model/imapConfig.model';
 import {emailConfigure} from '../core/emailConfigure';
 import {IMAP} from '../core/imap';
@@ -244,6 +244,23 @@ export class Panel {
             await joplin.settings.setValue(LAST_STATE, this.lastState);
         } else if (isHide(message)) {
             await this.closeOpenPanel();
+        } else if (isRefresh(message)) {
+            try {
+                await this.account.state();
+
+                // refresh mailboxes
+                const mailBoxes = await this.account.getBoxesPath();
+                this.lastState['mailBoxes'] = mailBoxes;
+                this.lastState['accountConfig'] = this.account.config;
+
+                // refresh joplin notebooks
+                const htmlMainScreen = await mainScreen(this.lastState);
+                await this.setHtml(htmlMainScreen);
+                await joplin.settings.setValue(LAST_STATE, this.lastState);
+            } catch (err) {
+                alert(err);
+                throw err;
+            }
         }
     }
 }

--- a/src/ui/screens.ts
+++ b/src/ui/screens.ts
@@ -392,7 +392,7 @@ export async function uploadMessagesScreen() {
           <div class="input-group mb-3">  
           <span class="input-group-text" id="basic-addon1"> Attachments Style </span>
           <select class="form-select" aria-label="Default select example" id = 'attachments_style'>
-            <option value="Tabel">Tabel</option>;
+            <option value="Table">Table</option>;
             <option value="Link">Link</option>;
           </select>
         </div>

--- a/src/ui/screens.ts
+++ b/src/ui/screens.ts
@@ -292,7 +292,7 @@ export async function mainScreen(lastState: State): Promise<string> {
           <div class="form-check form-switch">
             <input class="form-check-input" type="checkbox" role="switch" id="toggle-box"
               onchange="toggleBox()" ${checkedTogle}>
-            <label class="form-check-label" for="flexSwitchCheckChecked">Fetching & Monitoring MailBox</label>
+            <label class="form-check-label" for="flexSwitchCheckChecked">Fetching & Monitoring Mailbox</label>
           </div>
         </div>
         </div>

--- a/src/ui/screens.ts
+++ b/src/ui/screens.ts
@@ -1,0 +1,433 @@
+import joplin from 'api';
+import {State} from '../model/state.model';
+import {ACCOUNTS} from '../constants';
+import {JopinFolders} from '../model/joplinFolders.model';
+
+export function loadingScreen() {
+    return `
+  <div class="container">
+      <div class="row" style="font-size: large;">
+          <div class="col-md-9 col-lg-7 col-xl-5 mx-auto">
+              <div class="card border-0 shadow rounded-3 my-5" style="opacity: 0.97; top: 100px;">
+                  <div class="d-flex justify-content-center">
+                      <div class="spinner-border text-primary" role="status">
+                          <span class="sr-only">Loading...</span>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </div>
+  </div>
+  `;
+}
+
+export async function loginScreen() {
+    const accounts = await joplin.settings.value(ACCOUNTS);
+    const options: string[] = [];
+    let htmlAccounts = '';
+    for (const key of Object.keys(accounts)) {
+        const config = JSON.stringify( accounts[key]);
+        const option = `<option value=${config}>${key}</option>`;
+        options.push(option);
+    }
+    if (options.length) {
+        htmlAccounts = `
+      <div class="input-group mb-3">  
+      <span class="input-group-text" id="basic-addon1"> Accounts </span>
+      <select class="form-select" aria-label="Default select example" id = 'accounts'>
+        ${options}
+      </select>
+      <button onclick="selectedAccount()" id = "selectedAccount" class="btn btn-outline-primary btn-login text-uppercase fw-bold" type="submit" style="font-size:large;">Login</button>
+    </div>
+
+    <hr class="my-4">
+      `;
+    }
+    return `
+<div class="container">
+
+<div class="row" style="font-size: large;">
+
+  <div class="col-md-9 col-lg-7 col-xl-5 mx-auto">
+
+    <div class="card border-0 shadow rounded-3 my-3 align-middle d-flex justify-content-center" style="opacity: 0.97; top: 100px;" >
+
+      <div class="card-body p-4 p-sm-5">
+
+        <h1 class="card-title text-center mb-3 fw-light fs-1">Login</h1>
+
+        <form action="" onsubmit="login(); return false">
+          
+          <div class="form-floating mb-3">
+            <input type="email" class="form-control" id="email" placeholder="name@example.com" required>
+            <label for="floatingInput">Email address</label>
+          </div>
+          
+          <div class="form-floating mb-3">
+            <input type="password" class="form-control" id="password" placeholder="Password" onclick = "addBlockquote()"required>
+            <label for="floatingPassword">Password</label>
+          </div>
+
+          <blockquote class="blockquote">
+            <cite style = "font-size: 15px;" id = "quote"></cite>
+          </blockquote>
+
+          <div class="d-grid">
+            <button id="btn" class="btn btn-outline-primary btn-login text-uppercase fw-bold" type="submit" style="font-size:large;">Login</button>
+          </div>
+
+        </form>
+
+        <br>
+
+        <div class="container" style="text-align: center;">
+          <button type="button" class="btn btn-outline-info" style="width: 75%; font-size: large;" onclick="manualConnectionScreen()">Manually connect to IMAP</button>   
+          <br>
+          <br>
+          <button type="button" class="btn btn-outline-success" style="width: 75%; font-size: large;" onclick="uploadMessagesScreen()">Convert Saved Messages</button>
+        </div>
+
+        <hr class="my-4">
+
+        ${htmlAccounts}
+
+        <div class="container" style="text-align: center;">
+          <button type="button" class="btn btn-outline-danger" onclick="hide()">Close</button>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>
+</div>
+`;
+};
+
+export function manualScreen() {
+    return `<div class="container">
+
+<div class="row" style="font-size: large;">
+
+  <div class="col-md-9 col-lg-7 col-xl-5 mx-auto">
+
+  <div class="card border-0 shadow rounded-3 my-3 align-middle d-flex justify-content-center" style="opacity: 0.97; top: 100px;" >
+
+      <div class="card-body p-4 p-sm-5">
+
+        <h1 class="card-title text-center mb-3 fw-light fs-1">Login</h1>
+
+        <form action="" onsubmit="loginManually(); return false">
+          
+          <div class="form-floating mb-3">
+            <input type="email" class="form-control" id="email" placeholder="name@example.com" required>
+            <label for="floatingInput">Email address</label>
+          </div>
+          
+          <div class="form-floating mb-3">
+            <input type="password" class="form-control" id="password" placeholder="Password" onclick = "addBlockquote()" required>
+            <label for="floatingPassword">Password</label>
+          </div>
+
+          <div class="input-group">
+            <span class="input-group-text">Server</span>
+            <input type="text" aria-label="First name" class="form-control" placeholder="imap.example.com"
+              id="server" required>
+          </div>
+
+        <br>
+
+        <div class="input-group">
+          <span class="input-group-text">PORT</span>
+          <input type="number" aria-label="First name" class="form-control" placeholder="993" min="1" id="port" required>
+        </div>
+
+        <br>
+
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" value="" id="ssl_tls" checked>
+          <label class="form-check-label" for="ssl_tls">
+            SSL/TLS
+          </label>
+        </div>
+
+        <blockquote class="blockquote">
+          <cite style = "font-size: 15px;" id = "quote"></cite>
+        </blockquote>
+
+          <div class="d-grid">
+            <button id="btn" class="btn btn-outline-primary btn-login text-uppercase fw-bold" type="submit" style="font-size:large;">Login</button>
+          </div>
+
+        </form>
+
+        <br>
+
+        <div class="container" style="text-align: center;">
+          <button type="button" class="btn btn-outline-info" style="width: 75%; font-size: large;"
+            onclick="loginScreen()">Login Screen</button>
+        </div>
+
+        <hr class="my-4">
+
+        <div class="container" style="text-align: center;">
+          <button type="button" class="btn btn-outline-danger" onclick="hide()">Close</button>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>
+</div>
+`;
+}
+
+export async function mainScreen(lastState: State): Promise<string> {
+    const fromValue = lastState['from'];
+    let readOnly = '';
+    let checked = '';
+    let disabledFolders = '';
+    let disabledMailBoxes = '';
+    let checkedTogle = '';
+
+    if (lastState['isFromMonitor']) {
+        readOnly = 'readOnly';
+        checked = 'checked';
+    }
+
+    if (lastState['isMailBoxMonitor']) {
+        disabledMailBoxes = 'disabled';
+        disabledFolders = 'disabled';
+        checkedTogle = 'checked';
+    }
+
+    let joplinFolders: JopinFolders;
+    const folders = [];
+
+    do {
+        joplinFolders = await joplin.data.get(['folders']);
+
+        for (let i = 0; i < joplinFolders.items.length; i++) {
+            const folder = joplinFolders.items[i];
+            let path = folder.title;
+            let node = folder;
+            const id = folder.id;
+
+            // The parent folder path
+            while (node.parent_id !== '') {
+                node = await joplin.data.get(['folders', node.parent_id]);
+                path = `${node.title}/${path}`;
+            }
+            folders.push({path: path, id: id});
+        }
+    } while (joplinFolders.has_more);
+
+    const options = [];
+
+    folders.forEach((folder) => {
+        const option = lastState['folderId'] === folder.id ? `<option selected value="${folder.id}">${folder.path}</option>` : `<option value="${folder.id}">${folder.path}</option>`;
+        options.push(option);
+    });
+
+
+    const mailBoxesOptions = [];
+    lastState['mailBoxes'].forEach((element) => {
+        const option = lastState['mailBox'] === element.path ? `<option selected value="${element.value}">${element.path}</option>`: `<option value="${element.value}">${element.path}</option>`;
+        mailBoxesOptions.push(option);
+    });
+
+
+    return `
+<div class="container">
+
+<div class="row" style="font-size: large;">
+
+  <div class="col-md-9 col-lg-7 col-xl-5 mx-auto">
+
+  <div class="card border-0 shadow rounded-3 my-3 align-middle d-flex justify-content-center" style="opacity: 0.97; top: 100px;" >
+
+      <div class="card-body p-4 p-sm-5">
+
+        <h1 class="card-title text-center mb-3 fw-light fs-1">Main Screen</h1>
+
+        <div class="container" style="text-align: center;">
+
+          <div class="input-group mb-3">
+            <span class="input-group-text" id="basic-addon1">From</span>
+            <input type="email" class="form-control" placeholder="email" aria-label="Email"
+              aria-describedby="basic-addon1" id='from' value = "${fromValue}" ${readOnly} required>
+          </div>
+          <div class="container" style="text-align: center">
+            <div class="form-check form-switch">
+              <input class="form-check-input" type="checkbox" role="switch" id="toggle-from"
+                onchange="toggle()" ${checked}>
+              <label class="form-check-label" for="toggle-from">Fetching & Monitoring</label>
+            </div>
+          </div>
+        </div>
+
+        <br>
+
+        <div class="container" style="text-align: center;">
+          <div class="input-group mb-3">  
+            <span class="input-group-text" id="basic-addon1">MailBoxes</span>
+            <select class="form-select" aria-label="Default select example" id = 'mailbox' ${disabledMailBoxes}>
+              ${mailBoxesOptions}
+            </select>
+          </div>
+
+        <div class="input-group mb-3">
+          <span class="input-group-text" id="basic-addon1"> NoteBooks :</span>
+
+          <select class="form-select" aria-label="Default select example" id = 'notebook' ${disabledFolders}>
+            <option disabled selected value = "" >Open this select notebooks</option>
+            ${options}
+          </select>
+        </div>
+
+        <div class="container" style="text-align: center">
+          <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" role="switch" id="toggle-box"
+              onchange="toggleBox()" ${checkedTogle}>
+            <label class="form-check-label" for="flexSwitchCheckChecked">Fetching & Monitoring MailBox</label>
+          </div>
+        </div>
+        </div>
+        
+        <br>
+        
+
+        <div class="container" style="text-align: center;">
+          <button type="button" class="btn btn-outline-info" style="width: 75%; font-size: large;"
+            onclick="logout()">Logout</button>
+        </div>
+
+        <hr class="my-4">
+
+        <div class="container" style="text-align: center;">
+          <button type="button" class="btn btn-outline-danger" onclick="hide()">Close</button>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>
+</div>
+`;
+}
+
+export async function uploadMessagesScreen() {
+    let joplinFolders: JopinFolders;
+    const folders = [];
+
+    do {
+        joplinFolders = await joplin.data.get(['folders']);
+
+        for (let i = 0; i < joplinFolders.items.length; i++) {
+            const folder = joplinFolders.items[i];
+            let path = folder.title;
+            let node = folder;
+            const id = folder.id;
+
+            // The parent folder path
+            while (node.parent_id !== '') {
+                node = await joplin.data.get(['folders', node.parent_id]);
+                path = `${node.title}/${path}`;
+            }
+            folders.push({path: path, id: id});
+        }
+    } while (joplinFolders.has_more);
+
+    const options = [];
+
+    folders.forEach((folder) => {
+        const option = `<option value="${folder.id}">${folder.path}</option>`;
+        options.push(option);
+    });
+
+    return `
+<div class="container">
+
+<div class="row" style="font-size: large;">
+
+  <div class="col-md-9 col-lg-7 col-xl-5 mx-auto">
+
+  <div class="card border-0 shadow rounded-3 my-3 align-middle d-flex justify-content-center" style="opacity: 0.97; top: 100px;" >
+
+      <div class="card-body p-4 p-sm-5">
+
+        <h1 class="card-title text-center mb-3 fw-light fs-1">Upload .eml Files</h1>
+
+        <br>
+
+        <div class="container" style="text-align: center;">
+
+          <div class="mb-3">
+            <input class="form-control" type="file" id="formFileMultiple" accept=".eml" multiple>
+          </div>
+
+          <div class="input-group mb-3">
+          <span class="input-group-text" id="basic-addon1"> NoteBooks :</span>
+
+          <select class="form-select" aria-label="Default select example" id = 'notebook' onchange="createTag()">
+            <option disabled selected value >Open this select notebooks</option>
+            ${options}
+          </select>
+          
+          </div>
+
+          <div  class="input-group mb-3" id='div-tag'>
+
+          </div>
+
+          <div class="input-group mb-3">  
+            <span class="input-group-text" id="basic-addon1"> Export Type </span>
+            <select class="form-select" aria-label="Default select example" id = 'export_type'>
+              <option value="HTML">HTML</option>;
+              <option value="Markdown">Markdowm</option>;
+              <option value="Text">Text</option>;
+            </select>
+          </div>
+
+                  
+          <div class="input-group mb-3">  
+          <span class="input-group-text" id="basic-addon1"> Attachments Style </span>
+          <select class="form-select" aria-label="Default select example" id = 'attachments_style'>
+            <option value="Tabel">Tabel</option>;
+            <option value="Link">Link</option>;
+          </select>
+        </div>
+
+
+          <div class="container" style="text-align: center">
+            <input class="form-check-input" type="checkbox" id="include_attachments" checked>
+            <label class="form-check-label" for="include_attachments" style="padding-left: 5%;">
+              Include Attachments
+            </label>
+          </div>
+
+          <br>
+
+          <button id="btn" class="btn btn-outline-success btn-login text-uppercase fw-bold" type="submit"  onclick="uploadEMLfiles()" style="width: 75%; font-size:large;">Convert</button>
+
+        </div>
+
+        <br>
+
+        <div class="container" style="text-align: center;">
+          <button type="button" class="btn btn-outline-info" style="width: 75%; font-size: large;"
+            onclick="loginScreen()">Login Screen</button>
+        </div>
+
+        <hr class="my-4">
+
+        <div class="container" style="text-align: center;">
+          <button type="button" class="btn btn-outline-danger" onclick="hide()">Close</button>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>
+</div>
+`;
+}

--- a/src/ui/screens.ts
+++ b/src/ui/screens.ts
@@ -73,7 +73,7 @@ export async function loginScreen() {
           </blockquote>
 
           <div class="d-grid">
-            <button id="btn" class="btn btn-outline-primary btn-login text-uppercase fw-bold" type="submit" style="font-size:large;">Login</button>
+            <button id="login_btn" class="btn btn-outline-primary btn-login text-uppercase fw-bold" type="submit" style="font-size:large;">Login</button>
           </div>
 
         </form>
@@ -155,7 +155,7 @@ export function manualScreen() {
         </blockquote>
 
           <div class="d-grid">
-            <button id="btn" class="btn btn-outline-primary btn-login text-uppercase fw-bold" type="submit" style="font-size:large;">Login</button>
+            <button id="login_btn" class="btn btn-outline-primary btn-login text-uppercase fw-bold" type="submit" style="font-size:large;">Login</button>
           </div>
 
         </form>
@@ -189,7 +189,7 @@ export async function mainScreen(lastState: State): Promise<string> {
     let disabledMailBoxes = '';
     let checkedTogle = '';
 
-    if (lastState['isFromMonitor']) {
+    if (lastState['isEmailMonitor']) {
         readOnly = 'readOnly';
         checked = 'checked';
     }
@@ -407,7 +407,7 @@ export async function uploadMessagesScreen() {
 
           <br>
 
-          <button id="btn" class="btn btn-outline-success btn-login text-uppercase fw-bold" type="submit"  onclick="uploadEMLfiles()" style="width: 75%; font-size:large;">Convert</button>
+          <button id="convert_btn" class="btn btn-outline-success btn-login text-uppercase fw-bold" type="submit"  onclick="uploadEMLfiles()" style="width: 75%; font-size:large;">Convert</button>
 
         </div>
 

--- a/src/ui/screens.ts
+++ b/src/ui/screens.ts
@@ -246,8 +246,6 @@ export async function mainScreen(lastState: State): Promise<string> {
   <div class="card border-0 shadow rounded-3 my-3 align-middle d-flex justify-content-center" style="opacity: 0.97; top: 100px;" >
 
       <div class="card-body p-4 p-sm-5">
-
-        <button class="btn btn-primary input-group mb-3" style="width:20%; position:absolute; right:3px; top:3px" onclick="refresh()"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-clockwise" viewBox="0 0 16 16"> <path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z"/><path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z"/></svg>Refresh</button>    
         
         <h1 class="card-title text-center mb-3 fw-light fs-1">Main Screen</h1>
 
@@ -257,7 +255,7 @@ export async function mainScreen(lastState: State): Promise<string> {
             <span class="input-group-text" id="basic-addon1">From</span>
             <input type="email" class="form-control" placeholder="email" aria-label="Email"
               aria-describedby="basic-addon1" id='from' value = "${fromValue}" ${readOnly} required>
-              <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="top" title="Enter your email and forward the messages to yourself after editing the subject or first line of email content by adding @ or # to locate the notes folder or add tags. Otherwise, the converted messages from a specific email account will be in the 'email messages' folder. In both cases, new or unread messages will only be fetched."><span ><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/><path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/></svg> </span></button>
+              <button type="button" class="btn btn-secondary" style="margin-left: 5px;" title="Enter your email and forward the messages to yourself after editing the subject or first line of email content by adding @ or # to locate the notes folder or add tags. Otherwise, the converted messages from a specific email account will be in the 'email messages' folder. In both cases, new or unread messages will only be fetched."><span ><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/><path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/></svg> </span></button>
           </div>
           <div class="container" style="text-align: center">
             <div class="form-check form-switch">
@@ -272,20 +270,26 @@ export async function mainScreen(lastState: State): Promise<string> {
 
         <div class="container" style="text-align: center;">
           <div class="input-group mb-3">  
-            <span class="input-group-text" id="basic-addon1">Mailbox</span>
+            <span class="input-group-text" id="basic-addon1" style="display: inline-block; width:28%">Mailbox</span>
             
             <select class="form-select" aria-label="Default select example" id = 'mailbox' ${disabledMailBoxes}>
               ${mailBoxesOptions}
             </select>
+
+            <button class="btn btn-primary" style="margin-left: 5px;" onclick="refresh()"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-clockwise" viewBox="0 0 16 16"> <path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z"/><path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z"/></svg></button>
+          
           </div>
 
         <div class="input-group mb-3">
-          <span class="input-group-text" id="basic-addon1">Notebook</span>
+          <span class="input-group-text" id="basic-addon1" style="display: inline-block; width:28%">Notebook</span>
 
           <select class="form-select" aria-label="Default select example" id = 'notebook' ${disabledFolders}>
             <option disabled selected value = "" >Select a notebook</option>
             ${options}
           </select>
+
+          <button class="btn btn-primary" style="margin-left: 5px;" onclick="refresh()"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-clockwise" viewBox="0 0 16 16"> <path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z"/><path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z"/></svg></button>
+
         </div>
 
         <div class="container" style="text-align: center">

--- a/src/ui/screens.ts
+++ b/src/ui/screens.ts
@@ -247,6 +247,8 @@ export async function mainScreen(lastState: State): Promise<string> {
 
       <div class="card-body p-4 p-sm-5">
 
+        <button class="btn btn-primary input-group mb-3" style="width:20%; position:absolute; right:3px; top:3px" onclick="refresh()"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-clockwise" viewBox="0 0 16 16"> <path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z"/><path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z"/></svg>Refresh</button>    
+        
         <h1 class="card-title text-center mb-3 fw-light fs-1">Main Screen</h1>
 
         <div class="container" style="text-align: center;">
@@ -255,6 +257,7 @@ export async function mainScreen(lastState: State): Promise<string> {
             <span class="input-group-text" id="basic-addon1">From</span>
             <input type="email" class="form-control" placeholder="email" aria-label="Email"
               aria-describedby="basic-addon1" id='from' value = "${fromValue}" ${readOnly} required>
+              <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="top" title="Enter your email and forward the messages to yourself after editing the subject or first line of email content by adding @ or # to locate the notes folder or add tags. Otherwise, the converted messages from a specific email account will be in the 'email messages' folder. In both cases, new or unread messages will only be fetched."><span ><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/><path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/></svg> </span></button>
           </div>
           <div class="container" style="text-align: center">
             <div class="form-check form-switch">
@@ -269,17 +272,18 @@ export async function mainScreen(lastState: State): Promise<string> {
 
         <div class="container" style="text-align: center;">
           <div class="input-group mb-3">  
-            <span class="input-group-text" id="basic-addon1">MailBoxes</span>
+            <span class="input-group-text" id="basic-addon1">Mailbox</span>
+            
             <select class="form-select" aria-label="Default select example" id = 'mailbox' ${disabledMailBoxes}>
               ${mailBoxesOptions}
             </select>
           </div>
 
         <div class="input-group mb-3">
-          <span class="input-group-text" id="basic-addon1"> NoteBooks :</span>
+          <span class="input-group-text" id="basic-addon1">Notebook</span>
 
           <select class="form-select" aria-label="Default select example" id = 'notebook' ${disabledFolders}>
-            <option disabled selected value = "" >Open this select notebooks</option>
+            <option disabled selected value = "" >Select a notebook</option>
             ${options}
           </select>
         </div>
@@ -366,10 +370,10 @@ export async function uploadMessagesScreen() {
           </div>
 
           <div class="input-group mb-3">
-          <span class="input-group-text" id="basic-addon1"> NoteBooks :</span>
+          <span class="input-group-text" id="basic-addon1">Notebook</span>
 
           <select class="form-select" aria-label="Default select example" id = 'notebook' onchange="createTag()">
-            <option disabled selected value >Open this select notebooks</option>
+            <option disabled selected value >Select a notebook</option>
             ${options}
           </select>
           

--- a/src/ui/webview.js
+++ b/src/ui/webview.js
@@ -17,7 +17,7 @@ function login() {
 // When clicking on the 'Manually connect to IMAP' button.
 function manualConnectionScreen() {
     webviewApi.postMessage({
-        manual_connection_screen: true,
+        manualConnectionScreen: true,
     });
 }
 
@@ -31,7 +31,7 @@ function hide() {
 // When clicking on the 'login screen' button.
 function loginScreen() {
     webviewApi.postMessage({
-        login_screen: true,
+        loginScreen: true,
     });
 }
 
@@ -46,7 +46,7 @@ function loginManually() {
     disabledManualLoginScreen(true);
 
     webviewApi.postMessage({
-        login_manually: true,
+        loginManually: true,
         user: email,
         password: password,
         host: server,
@@ -82,7 +82,7 @@ function toggle() {
 
 function uploadMessagesScreen() {
     webviewApi.postMessage({
-        upload_messages_screen: true,
+        uploadMessagesScreen: true,
     });
 }
 
@@ -174,7 +174,7 @@ function selectedAccount() {
     disabledManualLoginScreen(true);
 
     webviewApi.postMessage({
-        login_manually: true,
+        loginManually: true,
         user: config.user,
         password: config.password,
         host: config.host,
@@ -217,7 +217,7 @@ function toggleBox() {
 function disabledLoginScreen(flag) {
     const emailInput = document.getElementById('email');
     const passwordInput = document.getElementById('password');
-    const loginBtn = document.getElementById('btn');
+    const loginBtn = document.getElementById('login_btn');
     if (flag === false) {
         emailInput.readOnly = passwordInput.readOnly = loginBtn.disabled = false;
         loginBtn.innerHTML = 'Login';
@@ -234,7 +234,7 @@ function disabledManualLoginScreen(flag) {
     const serverInput = document.getElementById('server');
     const portInput = document.getElementById('port');
     const sslTlsInput = document.getElementById('ssl_tls');
-    const loginBtn = document.getElementById('btn');
+    const loginBtn = document.getElementById('login_btn');
     const selectedAccountBtn = document.getElementById('selectedAccount');
 
     if (flag === false) {
@@ -265,7 +265,7 @@ function disabledUploadEMLScreen(flag) {
     const includeAttachmentsInput = document.getElementById('include_attachments');
     const exportTypeInput = document.getElementById('export_type');
     const attachmentsStyleInput = document.getElementById('attachments_style');
-    const loginBtn = document.getElementById('btn');
+    const loginBtn = document.getElementById('convert_btn');
 
     if (flag === false) {
         filesInput.disabled = folderInput.disabled = includeAttachmentsInput.disabled = exportTypeInput.disabled = attachmentsStyleInput.disabled = loginBtn.disabled = false;

--- a/src/ui/webview.js
+++ b/src/ui/webview.js
@@ -300,3 +300,9 @@ webviewApi.onMessage(({message})=>{
 function addBlockquote() {
     document.getElementById('quote').innerText = 'Make sure the email provider allows login using the original password; otherwise, use the app password.';
 }
+
+function refresh() {
+    webviewApi.postMessage({
+        refresh: false,
+    });
+}

--- a/src/ui/webview.js
+++ b/src/ui/webview.js
@@ -5,6 +5,8 @@ function login() {
     const email = document.getElementById('email').value;
     const password = document.getElementById('password').value;
 
+    disabledLoginScreen(true);
+
     webviewApi.postMessage({
         login: true,
         email: email,
@@ -13,9 +15,9 @@ function login() {
 }
 
 // When clicking on the 'Manually connect to IMAP' button.
-function manualConnection() {
+function manualConnectionScreen() {
     webviewApi.postMessage({
-        manual_connection: true,
+        manual_connection_screen: true,
     });
 }
 
@@ -37,9 +39,11 @@ function loginScreen() {
 function loginManually() {
     const email = document.getElementById('email').value;
     const password = document.getElementById('password').value;
-    const server = document.getElementById('server').value;
-    const sslTls = document.getElementById('ssl_tls').checked;
+    const server = document.getElementById('server').value.trim();
     const port = document.getElementById('port').value;
+    const sslTls = document.getElementById('ssl_tls').checked;
+
+    disabledManualLoginScreen(true);
 
     webviewApi.postMessage({
         login_manually: true,
@@ -54,6 +58,12 @@ function loginManually() {
 function toggle() {
     const from = document.getElementById('from').value;
     const readOnly = document.getElementById('from').readOnly;
+
+    if (from.trim() === '' && !readOnly) {
+        alert('Enter an email');
+        document.getElementById('toggle-from').checked = false;
+        return;
+    }
 
     // It sends an email and then closes input.
     if (!readOnly) {
@@ -70,9 +80,9 @@ function toggle() {
     }
 }
 
-function uploadMessages() {
+function uploadMessagesScreen() {
     webviewApi.postMessage({
-        upload_messages: true,
+        upload_messages_screen: true,
     });
 }
 
@@ -113,13 +123,20 @@ async function uploadEMLfiles() {
     const fileListLength = files.length;
     const folderId = document.getElementById('notebook').value;
     const tags = document.getElementById('tags');
+    const includeAttachments = document.getElementById('include_attachments').checked;
+    const exportType = document.getElementById('export_type').value;
+    const attachmentsStyle = document.getElementById('attachments_style').value;
+
+    disabledUploadEMLScreen(true);
 
     if (fileListLength === 0) {
         alert('Please upload .eml file(s)');
+        disabledUploadEMLScreen(false);
         return;
     } else if (!tags) {
         /* If tags input is not created, that means the user has not selected a notebook yet. */
         alert('Please Choose a NoteBook');
+        disabledUploadEMLScreen(false);
         return;
     }
 
@@ -137,5 +154,149 @@ async function uploadEMLfiles() {
         emlFiles: emlFiles,
         folderId: folderId,
         tags: tagsList,
+        exportType: exportType,
+        includeAttachments: includeAttachments,
+        attachmentsStyle: attachmentsStyle,
     });
+}
+
+function logout() {
+    webviewApi.postMessage({
+        logout: true,
+    });
+}
+
+function selectedAccount() {
+    const accountsInput = document.getElementById('accounts');
+    const account = accountsInput.value;
+    const config = JSON.parse(account);
+
+    disabledManualLoginScreen(true);
+
+    webviewApi.postMessage({
+        login_manually: true,
+        user: config.user,
+        password: config.password,
+        host: config.host,
+        port: config.port,
+        tls: config.tls,
+    });
+}
+
+function toggleBox() {
+    const mailbox = document.getElementById('mailbox').value;
+    const readOnly = document.getElementById('mailbox').disabled;
+    const folderId = document.getElementById('notebook').value;
+
+    if (folderId === '') {
+        /* If tags input is not created, that means the user has not selected a notebook yet. */
+        alert('Please Choose a NoteBook');
+        document.getElementById('toggle-box').checked = false;
+        return;
+    }
+    // It sends an email and then closes input.
+    if (!readOnly) {
+        document.getElementById('mailbox').disabled = !readOnly;
+        document.getElementById('notebook').disabled = !readOnly;
+
+        webviewApi.postMessage({
+            monitorMailBox: true,
+            mailbox: mailbox,
+            folderId: folderId,
+        });
+    } else {
+        document.getElementById('mailbox').disabled = !readOnly;
+        document.getElementById('notebook').disabled = !readOnly;
+
+        webviewApi.postMessage({
+            monitorMailBox: false,
+        });
+    }
+}
+
+function disabledLoginScreen(flag) {
+    const emailInput = document.getElementById('email');
+    const passwordInput = document.getElementById('password');
+    const loginBtn = document.getElementById('btn');
+    if (flag === false) {
+        emailInput.readOnly = passwordInput.readOnly = loginBtn.disabled = false;
+        loginBtn.innerHTML = 'Login';
+    } else {
+        loginBtn.disabled = emailInput.readOnly = passwordInput.readOnly = true;
+        const spinner = `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Loading...`;
+        loginBtn.innerHTML = spinner;
+    }
+}
+
+function disabledManualLoginScreen(flag) {
+    const emailInput = document.getElementById('email');
+    const passwordInput = document.getElementById('password');
+    const serverInput = document.getElementById('server');
+    const portInput = document.getElementById('port');
+    const sslTlsInput = document.getElementById('ssl_tls');
+    const loginBtn = document.getElementById('btn');
+    const selectedAccountBtn = document.getElementById('selectedAccount');
+
+    if (flag === false) {
+        if (selectedAccountBtn) {
+            selectedAccountBtn.disabled = false;
+            selectedAccountBtn.innerHTML = 'Login';
+        } else {
+            emailInput.readOnly = passwordInput.readOnly = serverInput.readOnly = portInput.readOnly = sslTlsInput.disabled = loginBtn.disabled = false;
+            loginBtn.innerHTML = 'Login';
+        }
+    } else {
+        if (selectedAccountBtn) {
+            selectedAccountBtn.disabled = true;
+            const spinner = `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Loading...`;
+            selectedAccountBtn.innerHTML = spinner;
+        } else {
+            emailInput.readOnly = passwordInput.readOnly = serverInput.readOnly = portInput.readOnly = sslTlsInput.disabled = loginBtn.disabled = true;
+            const spinner = `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Loading...`;
+            loginBtn.innerHTML = spinner;
+        }
+    }
+}
+
+function disabledUploadEMLScreen(flag) {
+    const filesInput = document.getElementById('formFileMultiple');
+    const folderInput = document.getElementById('notebook');
+    const tagsDiv = document.getElementById('div-tag');
+    const includeAttachmentsInput = document.getElementById('include_attachments');
+    const exportTypeInput = document.getElementById('export_type');
+    const attachmentsStyleInput = document.getElementById('attachments_style');
+    const loginBtn = document.getElementById('btn');
+
+    if (flag === false) {
+        filesInput.disabled = folderInput.disabled = includeAttachmentsInput.disabled = exportTypeInput.disabled = attachmentsStyleInput.disabled = loginBtn.disabled = false;
+        tagsDiv.style.pointerEvents = 'auto';
+        loginBtn.innerHTML = 'Convert';
+    } else {
+        filesInput.disabled = folderInput.disabled = includeAttachmentsInput.disabled = exportTypeInput.disabled = attachmentsStyleInput.disabled = true;
+        tagsDiv.style.pointerEvents = 'none';
+        const spinner = `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Loading...`;
+        loginBtn.disabled = true;
+        loginBtn.innerHTML = spinner;
+    }
+}
+
+webviewApi.onMessage(({message})=>{
+    if (message === 'enableLoginScreen') {
+        disabledLoginScreen(false);
+    } else if (message === 'enableManualLoginScreen') {
+        disabledManualLoginScreen(false);
+    } else if (message === 'enableUploadEMLScreen') {
+        disabledUploadEMLScreen(false);
+    } else if (message === 'monitoringError') {
+        webviewApi.postMessage({
+            state: 'open',
+        });
+        webviewApi.postMessage({
+            monitorMailBox: false,
+        });
+    }
+});
+
+function addBlockquote() {
+    document.getElementById('quote').innerText = 'Make sure the email provider allows login using the original password; otherwise, use the app password.';
 }

--- a/test/emailConfigure.test.ts
+++ b/test/emailConfigure.test.ts
@@ -88,17 +88,13 @@ describe('Testing various types of writing the email', () => {
         expect(config).toStrictEqual(answer);
     });
 
-    it('A provider that does not belong on the email provider list', () => {
+    it('If a provider is not on the email provider list, it will throw an error.', () => {
         const login: Login = {
             login: true,
             email: 'test@company.com',
             password: '12345',
         };
 
-        const config = emailConfigure(login);
-
-        const answer = undefined;
-
-        expect(config).toStrictEqual(answer);
+        expect(()=>emailConfigure(login)).toThrow(Error(`Sorry, an email provider couldn't be found, Please use the manual connection.`));
     });
 });

--- a/test/noteLocationBySubject.test.ts
+++ b/test/noteLocationBySubject.test.ts
@@ -1,0 +1,178 @@
+import {noteLocationBySubject} from '../src/core/noteLocationBySubject';
+
+describe('Naive Case.', ()=>{
+    it(`Extract 'joplin' as a note and 'note' as a tag.`, ()=>{
+        const loc = noteLocationBySubject('s @joplin #note');
+        const ans = {
+            folders: ['joplin'],
+            tags: ['note'],
+        };
+        expect(loc).toEqual(ans);
+    });
+
+    it('lowercase', ()=>{
+        const loc = noteLocationBySubject('@joplin #joplin');
+        const ans = {
+            folders: ['joplin'],
+            tags: ['joplin'],
+        };
+        expect(loc).toEqual(ans);
+    });
+
+    it('uppercase', ()=>{
+        const loc = noteLocationBySubject('@JOPLIN #JOPLIN');
+        const ans = {
+            folders: ['JOPLIN'],
+            tags: ['JOPLIN'],
+        };
+        expect(loc).toEqual(ans);
+    });
+});
+
+describe('The subject without folders or tags.', ()=>{
+    it(`It will return two empty arrays of subjects and tags in the subject that don't contain mentions and tags.`, ()=>{
+        const loc = noteLocationBySubject('subject test');
+        const ans = {
+            folders: [],
+            tags: [],
+        };
+        expect(loc).toEqual(ans);
+    });
+
+    it(`Empty subject.`, ()=>{
+        const loc = noteLocationBySubject('');
+        const ans = {
+            folders: [],
+            tags: [],
+        };
+        expect(loc).toEqual(ans);
+    });
+
+    it('Should ignore the empty mention or empty tag.', ()=>{
+        const loc = noteLocationBySubject('subject @ @ joplin @ @ @ @ @ # # # # # joplin # # joplin');
+        const ans = {
+            folders: [],
+            tags: [],
+        };
+        expect(loc).toEqual(ans);
+    });
+});
+
+describe('@ symbol between text.', ()=>{
+    it('Should ignore the @ symbol between text.', ()=>{
+        const loc = noteLocationBySubject('subject email@gmail.com test@test @joplin @email_plugin #joplin');
+        const ans = {
+            folders: ['joplin', 'email_plugin'],
+            tags: ['joplin'],
+        };
+        expect(loc).toEqual(ans);
+    });
+
+
+    it('Should ignore the @ symbol between text.', ()=>{
+        const loc = noteLocationBySubject('subject email@gmail.com test@test@joplin@email_plugin #joplin');
+        const ans = {
+            folders: [],
+            tags: ['joplin'],
+        };
+        expect(loc).toEqual(ans);
+    });
+
+
+    it('Should ignore the @ symbol inside an email.', ()=>{
+        const loc = noteLocationBySubject('subject email@gmail.com @joplin #joplin email2@gmail.com');
+        const ans = {
+            folders: ['joplin'],
+            tags: ['joplin'],
+        };
+        expect(loc).toEqual(ans);
+    });
+});
+
+
+describe('Special character.', ()=>{
+    it('Dealing with underscores within folders or emojis within tags', ()=>{
+        const loc = noteLocationBySubject('subject email@gmail.com test@test @joplin @email_plugin #joplin💖');
+        const ans = {
+            folders: ['joplin', 'email_plugin'],
+            tags: ['joplin💖'],
+        };
+        expect(loc).toEqual(ans);
+    });
+
+
+    it('Dealing with underscores within folders.', ()=>{
+        const loc = noteLocationBySubject('subject @50 @google.com @_gmail_proton*outlook');
+        const ans = {
+            folders: ['50', 'google.com', '_gmail_proton*outlook'],
+            tags: [],
+        };
+        expect(loc).toEqual(ans);
+    });
+});
+
+describe('# within the name of a folder or @ within the name of a tag.', ()=>{
+    it('# within the name of a folder.', ()=>{
+        const loc = noteLocationBySubject('subject @#go');
+        const ans = {
+            folders: ['#go'],
+            tags: [],
+        };
+        expect(loc).toEqual(ans);
+    });
+
+    it('@ within the name of a tag.', ()=>{
+        const loc = noteLocationBySubject('subject #@go');
+        const ans = {
+            folders: [],
+            tags: ['@go'],
+        };
+        expect(loc).toEqual(ans);
+    });
+});
+
+describe('Mention boundary.', ()=>{
+    it('Subject starts with mentioning a folder and ends with a tag.', ()=>{
+        const loc = noteLocationBySubject('@joplin subject #tag');
+        const ans = {
+            folders: ['joplin'],
+            tags: ['tag'],
+        };
+
+        expect(loc).toEqual(ans);
+    });
+
+    it('Subject starts with mentioning a tag and ends with a folder.', ()=>{
+        const loc = noteLocationBySubject('subect# #tag @subject@ @joplin # #  ＠go ﹫go');
+        const ans = {
+            folders: ['joplin', 'go', 'go'],
+            tags: ['tag'],
+        };
+
+        expect(loc).toEqual(ans);
+    });
+});
+
+describe('Irregular spaces.', ()=>{
+    it('should ignore irregular spaces between folders and tags.', ()=>{
+        const loc = noteLocationBySubject('why and but @note #note @good #tag  ');
+
+        const ans = {
+            folders: ['note', 'good'],
+            tags: ['note', 'tag'],
+        };
+
+        expect(loc).toEqual(ans);
+    });
+
+    it('should ignore irregular spaces between folders and tags.', ()=>{
+        const loc = noteLocationBySubject('     @note #note @good #tag  ');
+
+        const ans = {
+            folders: ['note', 'good'],
+            tags: ['note', 'tag'],
+        };
+
+        expect(loc).toEqual(ans);
+    });
+});

--- a/test/noteLocationBySubject.test.ts
+++ b/test/noteLocationBySubject.test.ts
@@ -33,7 +33,7 @@ describe('The subject without folders or tags.', ()=>{
     it(`It will return two empty arrays of subjects and tags in the subject that don't contain mentions and tags.`, ()=>{
         const loc = noteLocationBySubject('subject test');
         const ans = {
-            folders: [],
+            folders: ['email messages'],
             tags: [],
         };
         expect(loc).toEqual(ans);
@@ -42,7 +42,7 @@ describe('The subject without folders or tags.', ()=>{
     it(`Empty subject.`, ()=>{
         const loc = noteLocationBySubject('');
         const ans = {
-            folders: [],
+            folders: ['email messages'],
             tags: [],
         };
         expect(loc).toEqual(ans);
@@ -51,7 +51,7 @@ describe('The subject without folders or tags.', ()=>{
     it('Should ignore the empty mention or empty tag.', ()=>{
         const loc = noteLocationBySubject('subject @ @ joplin @ @ @ @ @ # # # # # joplin # # joplin');
         const ans = {
-            folders: [],
+            folders: ['email messages'],
             tags: [],
         };
         expect(loc).toEqual(ans);
@@ -72,7 +72,7 @@ describe('@ symbol between text.', ()=>{
     it('Should ignore the @ symbol between text.', ()=>{
         const loc = noteLocationBySubject('subject email@gmail.com test@test@joplin@email_plugin #joplin');
         const ans = {
-            folders: [],
+            folders: ['email messages'],
             tags: ['joplin'],
         };
         expect(loc).toEqual(ans);
@@ -124,7 +124,7 @@ describe('# within the name of a folder or @ within the name of a tag.', ()=>{
     it('@ within the name of a tag.', ()=>{
         const loc = noteLocationBySubject('subject #@go');
         const ans = {
-            folders: [],
+            folders: ['email messages'],
             tags: ['@go'],
         };
         expect(loc).toEqual(ans);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -124,7 +124,11 @@ const baseConfig = {
 				test: /\.tsx?$/,
 				use: 'ts-loader',
 				exclude: /node_modules/,
-			},
+			},{
+				include: /node_modules/,
+				test: /\.mjs$/,
+				type: 'javascript/auto'
+			  }
 		],
 	},
 };


### PR DESCRIPTION
# What has been done
- Added the feature of monitoring a specific mailbox or folder.
-  Added the feature of multi-user accounts.
- Added the feature of determining the folders and tags of the note based on the subject and the first line of email content.
- Added the feature of remembering the last state of the plugin even if the user closes the Joplin and reconnects when the plugin runs again.
- I've made some improvements in parallel
	- There has been a loading spinner added to all async buttons.
	- replace the embedded email text function in the email parser with [html-to-text](https://www.npmjs.com/package/html-to-text) ) (**higher in efficiency and extraction**).
	- I replaced the 'switch...case' in the panel bridge with 'if else' to make the code more readable.
	- Moved html screens from the panel file to an external file `screens`.


When I installed ` html-to-text`, I found an error when compiling, and I modified the webpack file in rules to add read mjs for the grammar file [link](https://stackoverflow.com/questions/69343038/cant-import-the-named-export-xxxx-from-non-ecmascript-module-only-default-expo#:~:text=%7B%0A%20%20%20%20%20%20%20%20test%3A%20/%5C.mjs%24/%2C%0A%20%20%20%20%20%20%20%20include%3A%20/node_modules/%2C%0A%20%20%20%20%20%20%20%20type%3A%20%27javascript/auto%27%0A%20%20%20%20%20%20%7D).