### PR TITLE
style: fix spelling

### DIFF
--- a/src/ui/screens.ts
+++ b/src/ui/screens.ts
@@ -391,7 +391,7 @@ export async function uploadMessagesScreen() {
             <span class="input-group-text" id="basic-addon1"> Export Type </span>
             <select class="form-select" aria-label="Default select example" id = 'export_type'>
               <option value="HTML">HTML</option>;
-              <option value="Markdown">Markdowm</option>;
+              <option value="Markdown">Markdown</option>;
               <option value="Text">Text</option>;
             </select>
           </div>


### PR DESCRIPTION
Fix the spelling of "markdown" on the "Upload .eml Files" UI under the drop-down menu for "Export Type".
![image](https://user-images.githubusercontent.com/28695573/193144277-4366a993-f986-4ede-b43b-4ea45676e310.png)
