### PR TITLE
feature/Add tags mentioned in the subject to the note when monitoring a specific mailbox.

### DIFF
--- a/src/core/postNote.ts
+++ b/src/core/postNote.ts
@@ -95,7 +95,12 @@ export class PostNote {
 
         if (isPostByFolderId(postCriteria)) {
             this.note['parent_id'] = postCriteria['folderId'];
-            emailTags = await this.addTags(postCriteria['tags']);
+            const subject = postCriteria['emailContent'].subject;
+            const emailText = htmlToText(this.emailHtmlBody, {wordwrap: 130, selectors: [{selector: 'img', format: 'skip'}]});
+            const firstLine = (emailText || '').trim().split('\n')[0];
+            const {tags} = noteLocationBySubject(subject + ' ' + firstLine);
+
+            emailTags = await this.addTags(tags);
 
             // Post the note to Joplin.
             const note = await joplin.data.post(['notes'], null, this.note);


### PR DESCRIPTION
Add tags mentioned in the subject or first line of email content to the note when monitoring a specific mailbox.


https://user-images.githubusercontent.com/58605547/193354109-11868649-1166-4ab5-851c-2fce8e85a092.mp4

