### PR TITLE
Add Strato.de email provider configure #13

### DIFF
--- a/src/core/emailProviders.ts
+++ b/src/core/emailProviders.ts
@@ -51,4 +51,10 @@ export const emailProviders: EmailProvider[] = [
         tls: true,
     },
 
+    {
+        type: 'strato',
+        host: 'imap.strato.de',
+        port: 993,
+        tls: true,
+    },
 ];


### PR DESCRIPTION
To connect any of "example@strato.de" emails to IMAP without the need for a manual connection.